### PR TITLE
CI: add auto-update SDK upon API spec updates

### DIFF
--- a/.github/workflows/check-api-spec-updates.yaml
+++ b/.github/workflows/check-api-spec-updates.yaml
@@ -6,18 +6,17 @@ on:
   workflow_dispatch:
 
 jobs:
-  compare_to_new_spec:
+  main:
+    permissions:
+      pull-requests: write
+      contents: write
     runs-on: ubuntu-latest
-    name: Compare to new API spec
     outputs:
       isNew: ${{ steps.diff_sdk.outputs.isNew }}
     steps:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - uses: actions/setup-go@v4
-        with:
-          go-version: 1.18
       - name: Pull new spec
         run: |
           curl -SLo openAPIDefinition_new.json "$SPEC_URL"
@@ -31,6 +30,10 @@ jobs:
           else
             echo "isNew=false" >> $GITHUB_OUTPUT
           fi
+      - uses: actions/setup-go@v4
+        if: steps.diff.outputs.isNew == 'true'
+        with:
+          go-version: 1.18
       - name: Generate SDK using new spec
         id: diff_sdk
         if: steps.diff.outputs.isNew == 'true'
@@ -48,12 +51,37 @@ jobs:
             fi
           done
 
+      - name: MV new sdk to root
+        run: |
+          mv ${PWD}/tmp/* .
+          mv openAPIDefinition_new.json openAPIDefinition.json
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v5
+        with:
+          add-paths: |
+            *.go
+            go.mod
+            openAPIDefinition.json
+          commit-message: |
+            feat: auto-updated SDK
+          signoff: true
+          branch: feat/auto-generated-new-api-spec
+          branch-suffix: timestamp
+          delete-branch: true
+          title: Auto-generated SDK upon new spec
+          body: |
+            ## What changed
+              New generated SDK
+            ## Why do we need it
+              To reflect API spec changes
+
   notify:
     runs-on: ubuntu-latest
     name: Notify
     needs:
-      - compare_to_new_spec
-    if: needs.compare_to_new_spec.outputs.isNew == 'true'
+      - main
+    if: needs.main.outputs.isNew == 'true'
     steps:
       - name: Telegram
         uses: appleboy/telegram-action@master

--- a/.github/workflows/check-api-spec-updates.yaml
+++ b/.github/workflows/check-api-spec-updates.yaml
@@ -13,6 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       isNew: ${{ steps.diff_sdk.outputs.isNew }}
+      prId: ${{ steps.pr.outputs.pull-request-number }}
     steps:
       - uses: actions/checkout@v3
         with:
@@ -52,12 +53,15 @@ jobs:
           done
 
       - name: MV new sdk to root
+        if: steps.diff_sdk.outputs.isNew == 'true'
         run: |
           mv ${PWD}/tmp/* .
           mv openAPIDefinition_new.json openAPIDefinition.json
 
       - name: Create Pull Request
+        if: steps.diff_sdk.outputs.isNew == 'true'
         uses: peter-evans/create-pull-request@v5
+        id: pr
         with:
           add-paths: |
             *.go
@@ -69,6 +73,7 @@ jobs:
           branch: feat/auto-generated-new-api-spec
           branch-suffix: timestamp
           delete-branch: true
+          assignees: kislerdm
           title: Auto-generated SDK upon new spec
           body: |
             ## What changed
@@ -90,6 +95,7 @@ jobs:
           token: ${{ secrets.TELEGRAM_TOKEN }}
           message: |
             New Neon API spec has been detected. Please take action.
+            PR: https://github.com/kislerdm/neon-sdk-go/pull/${{ needs.main.outputs.prId }}
 
             The message was sent from https://github.com/kislerdm/neon-sdk-go
             Get in touch for details: admin@dkisler.com
@@ -100,10 +106,9 @@ jobs:
               -H "Title: Neon API Spec Updated" \
               -H "Priority: urgent" \
               -H "Tags: warning" \
-              -H "Actions: view, Open API Spec, https://api-docs.neon.tech/; \
-                           view, Open Repo, https://github.com/kislerdm/neon-sdk-go; \
-                           view, Send Email to maintainer, mailto:admin@dkisler.com?subject=[alert]Neon-API-Updated" \
+              -H "Actions: view, Open Repo: https://github.com/kislerdm/neon-sdk-go" \
               -d "New Neon API spec has been detected. Please take action.
+            PR: https://github.com/kislerdm/neon-sdk-go/pull/${{ needs.main.outputs.prId }}
           
             The message was sent from https://github.com/kislerdm/neon-sdk-go
             Get in touch for details: admin@dkisler.com" \

--- a/.github/workflows/check-api-spec-updates.yaml
+++ b/.github/workflows/check-api-spec-updates.yaml
@@ -10,17 +10,20 @@ jobs:
     runs-on: ubuntu-latest
     name: Compare to new API spec
     outputs:
-      isNew: ${{ steps.diff.outputs.isNew }}
+      isNew: ${{ steps.diff_sdk.outputs.isNew }}
     steps:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 1
+      - uses: actions/setup-go@v4
+        with:
+          go-version: 1.18
       - name: Pull new spec
         run: |
           curl -SLo openAPIDefinition_new.json "$SPEC_URL"
         env:
           SPEC_URL: https://dfv3qgd2ykmrx.cloudfront.net/api_spec/release/v2.json
-      - name: Diff
+      - name: Diff spec files
         id: diff
         run: |
           if [ $(diff openAPIDefinition_new.json openAPIDefinition.json | wc -l) -gt 0 ]; then
@@ -28,6 +31,23 @@ jobs:
           else
             echo "isNew=false" >> $GITHUB_OUTPUT
           fi
+      - name: Generate SDK using new spec
+        id: diff_sdk
+        if: steps.diff.outputs.isNew == 'true'
+        run: |
+          echo "isNew=false" >> $GITHUB_OUTPUT
+          
+          mkdir tmp
+          make generate-sdk PATH_SPEC=${PWD}/openAPIDefinition_new.json PATH_SDK=${PWD}/tmp
+          
+          for obj in $(ls ${PWD}/tmp); do
+            echo check ${obj}
+            if [ $(diff ${obj} ${PWD}/tmp/${obj} | wc -l) -gt 0 ]; then
+              echo diff in SDK generated using new new spec, file ${obj}
+              echo "isNew=true" >> $GITHUB_OUTPUT
+            fi
+          done
+
   notify:
     runs-on: ubuntu-latest
     name: Notify

--- a/Makefile
+++ b/Makefile
@@ -14,8 +14,9 @@ PATH_SDK := $(PWD)
 
 .PHONY: generate-sdk
 generate-sdk: ## Generates the SDK codebase using code generator.
-	@ make build DIR=generator
-	@ ./generator/bin/generator-$(OS)-$(ARCH) --output $(PATH_SDK) --input $(PATH_SPEC)
+	@ cd generator && \
+		go mod tidy && \
+		CGO_ENABLED=0 go run cmd/main.go --output $(PATH_SDK) --input $(PATH_SPEC)
 
 .PHONY: tests
 tests: ## Run tests.


### PR DESCRIPTION
## What changed

- Added CI step to verify if new API spec affect SDK
- Added CI step to open PR if SDK was modified as the consequence of API spec modifications

## Why do we need it

- To streamline released and be up to date with the API specs
- To reduce alerts noise
