### PR TITLE
Fix ListProjects when ContentLength header is not defined

### DIFF
--- a/sdk.go
+++ b/sdk.go
@@ -453,18 +453,6 @@ func (c *client) requestHandler(url string, t string, reqPayload interface{}, re
 		return convertErrorResponse(res)
 	}
 
-	// cover non-existing object which will have 200+ status code
-	// see the ticket https://github.com/neondatabase/neon/issues/2159
-	if req.Method == "GET" && res.ContentLength < 4 {
-		return Error{
-			HTTPCode: 404,
-			errorResp: errorResp{
-				Code:    "",
-				Message: "object not found",
-			},
-		}
-	}
-
 	if responsePayload != nil {
 		buf, err := io.ReadAll(res.Body)
 		defer func() { _ = res.Body.Close() }()


### PR DESCRIPTION
Hello :wave:,

Currently, it's not possible to use the [ListProjects](https://github.com/kislerdm/neon-sdk-go/blob/137b21d97114b49574811e61ed780171abc8e53d/sdk.go#L99) without receiving an "object not found" error _(but not always)_.

This error is returned because `https://console.neon.tech/api/v2/projects` doesn't return the `ContentLength` when the list of projects is quite large.

From my understanding, it was a protection that you made for the first version of Neon API but looking at the [issue](https://github.com/neondatabase/neon/issues/2159), it seems this behavior was fixed ?!

Have a great day and thank you for taking the time to review this.