### PR TITLE
fix: resolve stack overflow in SDK generator and improve workflow

### DIFF
--- a/.github/workflows/check-api-spec-updates.yaml
+++ b/.github/workflows/check-api-spec-updates.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: Pull new spec
         run: make fetch-specs
       - name: Diff spec files
-        id: diff
+        id: diff_spec
         run: |
           if [ $(diff openAPIDefinition_new.json openAPIDefinition.json | wc -l) -gt 0 ]; then
             echo "isNew=true" >> $GITHUB_OUTPUT
@@ -29,12 +29,12 @@ jobs:
             echo "isNew=false" >> $GITHUB_OUTPUT
           fi
 #      - uses: actions/setup-go@v5
-#        if: steps.diff.outputs.isNew == 'true'
+#        if: steps.diff_spec.outputs.isNew == 'true'
 #        with:
 #          go-version-file: generator/go.mod
 #      - name: Generate SDK using new spec
 #        id: diff_sdk
-#        if: steps.diff.outputs.isNew == 'true'
+#        if: steps.diff_spec.outputs.isNew == 'true'
 #        run: |
 #          echo "isNew=false" >> $GITHUB_OUTPUT
 #
@@ -49,12 +49,45 @@ jobs:
 #            fi
 #          done
 
-      - name: MV new sdk to root
-        if: steps.diff_sdk.outputs.isNew == 'true'
-        run: mv openAPIDefinition_new.json openAPIDefinition.json
+      - name: Update API spec and create PR body
+        id: create_pr_body
+        if: steps.diff_spec.outputs.isNew == 'true'
+        run: |
+          TMP_FILE_NEW="/tmp/new.txt"
+          TMP_FILE_OLD="/tmp/old.txt"
+
+          # Pluck the summary attribute from each entry (http method named attributes)
+          jq -r '.paths | to_entries[] | .key as $path | .value | to_entries[] | select(.key | test("^(get|post|put|delete|patch|options|head|trace)$")) | .value.summary' openAPIDefinition_new.json > $TMP_FILE_NEW
+          jq -r '.paths | to_entries[] | .key as $path | .value | to_entries[] | select(.key | test("^(get|post|put|delete|patch|options|head|trace)$")) | .value.summary' openAPIDefinition.json > $TMP_FILE_OLD
+
+          # Segment additions and removals, format with dashes for markdown list
+          ADDED=$(diff $TMP_FILE_OLD $TMP_FILE_NEW | grep '>' | sed 's/>/\n-/' || true)
+          REMOVED=$(diff $TMP_FILE_OLD $TMP_FILE_NEW | grep '<' | sed 's/</\n-/' || true)
+
+          # Build changes output
+          CHANGES=""
+          if [ -n "$ADDED" ]; then
+            CHANGES="${CHANGES}\n\n### Added API Methods\n\n${ADDED}"
+          fi
+
+          if [ -n "$REMOVED" ]; then
+            CHANGES="${CHANGES}\n\n### Removed API Methods\n\n${REMOVED}"
+          fi
+
+          # Replace previous version of spec with new version
+          mv openAPIDefinition_new.json openAPIDefinition.json
+
+          # Output PR body content
+          {
+            echo "api_changes<<EOF"
+            echo -e "$CHANGES"
+            echo "EOF"
+          }  >> $GITHUB_OUTPUT
+
+          cat $GITHUB_OUTPUT
 
       - name: Create Pull Request
-        if: steps.diff_sdk.outputs.isNew == 'true'
+        if: steps.diff_spec.outputs.isNew == 'true'
         uses: peter-evans/create-pull-request@v6
         id: pr
         with:
@@ -66,10 +99,13 @@ jobs:
           branch-suffix: timestamp
           delete-branch: true
           assignees: kislerdm
-          title: New spec detected
+          title: Updates from Neon API spec
           body: |
             ## What changed
-              New API spec added
+              New API specs.
+
+              ${{ steps.create_pr_body.outputs.api_changes }}
+
             ## Why do we need it
               To reflect API spec changes
 

--- a/.github/workflows/check-api-spec-updates.yaml
+++ b/.github/workflows/check-api-spec-updates.yaml
@@ -28,26 +28,26 @@ jobs:
           else
             echo "isNew=false" >> $GITHUB_OUTPUT
           fi
-#      - uses: actions/setup-go@v5
-#        if: steps.diff_spec.outputs.isNew == 'true'
-#        with:
-#          go-version-file: generator/go.mod
-#      - name: Generate SDK using new spec
-#        id: diff_sdk
-#        if: steps.diff_spec.outputs.isNew == 'true'
-#        run: |
-#          echo "isNew=false" >> $GITHUB_OUTPUT
-#
-#          mkdir tmp
-#          make generate-sdk PATH_SPEC=${PWD}/openAPIDefinition_new.json PATH_SDK=${PWD}/tmp
-#
-#          for obj in $(ls ${PWD}/tmp); do
-#            echo check ${obj}
-#            if [ $(diff ${obj} ${PWD}/tmp/${obj} | wc -l) -gt 0 ]; then
-#              echo diff in SDK generated using new new spec, file ${obj}
-#              echo "isNew=true" >> $GITHUB_OUTPUT
-#            fi
-#          done
+      - uses: actions/setup-go@v5
+        if: steps.diff_spec.outputs.isNew == 'true'
+        with:
+          go-version-file: generator/go.mod
+      - name: Generate SDK using new spec
+        id: diff_sdk
+        if: steps.diff_spec.outputs.isNew == 'true'
+        run: |
+          echo "isNew=false" >> $GITHUB_OUTPUT
+
+          mkdir tmp
+          make generate-sdk PATH_SPEC=${PWD}/openAPIDefinition_new.json PATH_SDK=${PWD}/tmp
+
+          for obj in $(ls ${PWD}/tmp); do
+            echo check ${obj}
+            if [ $(diff ${obj} ${PWD}/tmp/${obj} | wc -l) -gt 0 ]; then
+              echo diff in SDK generated using new new spec, file ${obj}
+              echo "isNew=true" >> $GITHUB_OUTPUT
+            fi
+          done
 
       - name: Update API spec and create PR body
         id: create_pr_body

--- a/generator/generator.go
+++ b/generator/generator.go
@@ -541,6 +541,11 @@ func filterModels(modelsSource models, output models, m model) {
 		return
 	}
 
+	// Check if already processed to prevent infinite recursion
+	if _, exists := output[v.name]; exists {
+		return
+	}
+
 	output[v.name] = v
 
 	for child := range v.children {


### PR DESCRIPTION
## What changed

  - Fixed infinite recursion in `filterModels` causing stack overflow when processing circular model references in API specs
  - Added `api_changes` output to automatic PR bodies
  - Re-enabled SDK generation step in CI workflow

## Why

The SDK generator seemed to crash with a stack overflow when the API spec contained circular references (e.g., Branch -> Project -> Branch). Added a check to skip already-processed models, which should hopefully prevent infinite recursion.

Ultimately, there a new API resources available that haven't been introduced into the SDK yet and I'm hoping a fix for the workflow might streamline the process for the maintainer.